### PR TITLE
bump `linked_list_allocator` (`0.9` -> `0.10(.5)`)

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.9.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
+checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 dependencies = [
  "spinning_top",
 ]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -14,7 +14,7 @@ x86_64 = "0.14"
 uart_16550 = "0.3"
 pic8259 = "0.11"
 pc-keyboard = "0.7"
-linked_list_allocator = "0.9"
+linked_list_allocator = "0.10"
 
 [dependencies.bootloader]
 version = "0.9"

--- a/kernel/src/allocator.rs
+++ b/kernel/src/allocator.rs
@@ -12,7 +12,7 @@ pub mod bump;
 pub mod fixed_size_block;
 pub mod linked_list;
 
-pub const HEAP_START: usize = 0x_4444_4444_0000;
+pub const HEAP_START: *mut u8 = 0x_4444_4444_0000 as *mut u8;
 pub const HEAP_SIZE: usize = 100 * 1024; // 100 KiB
 
 #[global_allocator]

--- a/kernel/src/allocator/fixed_size_block.rs
+++ b/kernel/src/allocator/fixed_size_block.rs
@@ -32,7 +32,7 @@ impl FixedSizeBlockAllocator {
         }
     }
 
-    pub unsafe fn init(&mut self, heap_start: usize, heap_size: usize) {
+    pub unsafe fn init(&mut self, heap_start: *mut u8, heap_size: usize) {
         self.fallback_allocator.init(heap_start, heap_size);
     }
 


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2022-0063.html